### PR TITLE
Refactor path logic and simplify source resolution

### DIFF
--- a/src/patterns/matcherContextPatch.ts
+++ b/src/patterns/matcherContextPatch.ts
@@ -39,16 +39,17 @@ export async function matcherContextAddPath(
 		return false
 	}
 
+	const isDir = entry.endsWith("/")
+	const direntPath = isDir ? entry.slice(0, -1) : entry
+	if (isDir && direntPath === ".") {
+		return true
+	}
+	const parentPath = dirname(direntPath)
+
 	const { target, fs, cwd, signal, depth: maxDepth } = options
 
-	const isDir = entry.endsWith("/")
 	if (isDir) {
 		// recursive parent population
-		const direntPath = entry.replace(/\/$/, "")
-		if (direntPath === ".") {
-			return true
-		}
-		const parentPath = dirname(direntPath)
 		const resource = await new Promise<Resource>((resolve, reject) => {
 			resolveSources(
 				{
@@ -90,8 +91,6 @@ export async function matcherContextAddPath(
 		}
 		return true
 	}
-
-	const parentPath = dirname(entry)
 
 	const isSource = target.extractors.some((e) => e.path === entry)
 	if (isSource) {
@@ -182,17 +181,19 @@ export async function matcherContextRemovePath(
 	entry: string,
 ): Promise<boolean> {
 	const isDir = entry.endsWith("/")
+	const direntPath = isDir ? entry.slice(0, -1) : entry
+	if (isDir && direntPath === ".") {
+		ctx.paths.clear()
+		ctx.external.clear()
+		ctx.failed.length = 0
+		ctx.total.set(direntPath, { totalDirs: 0, totalFiles: 0, totalMatchedFiles: 0 })
+		return true
+	}
+	const parentPath = dirname(direntPath)
+	const parentPathDir = parentPath + "/"
+
 	if (isDir) {
 		// remove directories
-		const direntPath = entry.slice(0, -1)
-		if (direntPath === ".") {
-			ctx.paths.clear()
-			ctx.external.clear()
-			ctx.failed.length = 0
-			ctx.total.set(direntPath, { totalDirs: 0, totalFiles: 0, totalMatchedFiles: 0 })
-			return true
-		}
-
 		let deletedDirs = 0,
 			deletedFiles = 0
 		const total = ctx.total.get(direntPath)!
@@ -228,9 +229,6 @@ export async function matcherContextRemovePath(
 		}
 		return true
 	}
-
-	const parentPath = dirname(entry)
-	const parentPathDir = parentPath + "/"
 
 	const isSource = options.target.extractors.some((e) => e.path === entry)
 	if (isSource) {

--- a/src/patterns/resolveSources.ts
+++ b/src/patterns/resolveSources.ts
@@ -7,7 +7,7 @@ import type { Resource } from "./resource.js"
 import type { Rule } from "./rule.js"
 import type { Source } from "./source.js"
 
-import { dirname, join } from "../unixify.js"
+import { join } from "../unixify.js"
 import { type PatternFinderOptions, type Extractor } from "./extractor.js"
 import { patternListCompile } from "./patternList.js"
 
@@ -87,43 +87,40 @@ export function resolveSources(
 	const noSourceDirList: string[] = [dir]
 
 	if (dir !== ".") {
-		dir = dirname(dir)
-
-		// find source from an ancestor [dir < ... < cwd]
-		while (true) {
+		const segments = dir.split("/")
+		for (let i = segments.length - 1; i >= 0; i--) {
 			if (signal?.aborted) {
 				cb(signal.reason, null)
 				return
 			}
-			source = external.get(dir)
+			const d = segments.slice(0, i).join("/") || "."
+			source = external.get(d)
 			if (source !== undefined) {
+				dir = d
 				break
 			}
-			noSourceDirList.push(dir)
-			const parent = dirname(dir)
-			if (dir === parent) break
-			dir = parent
-			continue
+			noSourceDirList.push(d)
+			if (d === ".") {
+				dir = "."
+				break
+			}
 		}
 	}
 
 	// find non-cwd source [root > cwd) and populate [cwd > ... > dir]
 
-	const preCwdSegments: string[] = []
 	if (target.root.charCodeAt(0) === 47) {
 		// "/"
-		let c = dirname(cwd)
-		while (true) {
-			if (signal?.aborted) {
-				cb(signal.reason, null)
-				return
+		const segments = cwd.split("/")
+		const preCwdSegments: string[] = []
+		let current = ""
+		for (let i = 0, len = segments.length - 1; i < len; i++) {
+			current += segments[i] + "/"
+			const path = current.length > 1 ? current.slice(0, -1) : "/"
+			if (path.length >= target.root.length) {
+				preCwdSegments.push(path)
 			}
-			preCwdSegments.push(c)
-			if (c === target.root) break
-			const parent = dirname(c)
-			c = parent
 		}
-		preCwdSegments.reverse()
 
 		findSourceForAbsoluteDirsCb(preCwdSegments, fs, target, signal, (err, source) => {
 			if (err) {


### PR DESCRIPTION
Consolidated path normalization and parent traversal in `matcherContextPatch.ts` and simplified path searches in `resolveSources.ts` using segment iterators.

---
*PR created automatically by Jules for task [16112515803555454502](https://jules.google.com/task/16112515803555454502) started by @Mopsgamer*