### PR TITLE
fix: TypeScript compatibility (4.x-7.x) and EventTarget types

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "view-ignored",
@@ -23,6 +22,8 @@
         "oxlint-tsgolint": "latest",
         "publint": "latest",
         "release-it": "latest",
+        "typescript4": "npm:typescript@~4.9.5",
+        "typescript6": "^6.0.0-dev.20260416",
       },
     },
   },
@@ -512,6 +513,10 @@
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "type-fest": ["type-fest@2.19.0", "", {}, "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="],
+
+    "typescript4": ["typescript@4.9.5", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="],
+
+    "typescript6": ["typescript@6.0.0-dev.20260416", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-64CCow5rQc6+oBAPqLtvZ8f3iz4WVCLwMVkg6/kOfMQlGshVOMkBhCXn+MMP4SX4Xtnz48VpD98FkptirMEuEQ=="],
 
     "undici": ["undici@7.24.5", "", {}, "sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q=="],
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,18 @@
 		"/out"
 	],
 	"type": "module",
+	"typesVersions": {
+		">=6.0": {
+			"out/patterns/matcherStream.d.ts": [
+				"ts-compat/ts6.0/patterns/matcherStream.d.ts"
+			]
+		},
+		">=4.7": {
+			"out/patterns/matcherStream.d.ts": [
+				"ts-compat/ts4.7/patterns/matcherStream.d.ts"
+			]
+		}
+	},
 	"exports": {
 		".": {
 			"types": "./out/index.d.ts",
@@ -76,7 +88,7 @@
 		"access": "public"
 	},
 	"scripts": {
-		"prerelease": "bun run test && bun run prod && bun run lint && bun run fmt --check && bun publint --pack bun --strict",
+		"prerelease": "bun run test && bun run prod && bun run lint && bun run fmt --check && bun run ts-compat && bun publint --pack bun --strict",
 		"heap": "bun scripts/scanHeap.js --snapshot",
 		"heap:node": "node scripts/scanHeap.js --snapshot",
 		"cpu": "bun run --expose-gc --cpu-prof --cpu-prof-md --cpu-prof-name CPU.me scripts/scan.js --fastInternal",
@@ -95,6 +107,7 @@
 		"check": "bun tsgo -p src --noEmit",
 		"dev": "bun tsgo -p src",
 		"prod": "rm -rf out && bun tsgo -p src/tsconfig.prod.json",
+		"ts-compat": "./node_modules/typescript4/bin/tsc -p src/tsconfig.prod.json && ./node_modules/typescript6/bin/tsc -p src/tsconfig.prod.json",
 		"release:major": "bun run --bun release-it --increment=major",
 		"release:minor": "bun run --bun release-it --increment=minor",
 		"release:patch": "bun run --bun release-it --increment=patch"
@@ -117,7 +130,9 @@
 		"oxlint": "latest",
 		"oxlint-tsgolint": "latest",
 		"publint": "latest",
-		"release-it": "latest"
+		"release-it": "latest",
+		"typescript4": "npm:typescript@~4.9.5",
+		"typescript6": "^6.0.0-dev.20260416"
 	},
 	"engines": {
 		"node": ">=18"

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,4 +1,4 @@
 export { scan } from "./browser_scan.js"
 export { scanCb } from "./scanCb.js"
 export { scanStream as stream } from "./browser_stream.js"
-export type * from "./types.js"
+export * from "./types.js"

--- a/src/browser_scan.ts
+++ b/src/browser_scan.ts
@@ -3,7 +3,7 @@ import type { ScanOptions, FsAdapter } from "./types.js"
 
 import { scanCb } from "./scanCb.js"
 export { scanCb } from "./scanCb.js"
-export type * from "./types.js"
+export * from "./types.js"
 
 /**
  * Scan the directory for included files based on the provided targets.
@@ -18,7 +18,12 @@ export type * from "./types.js"
 export function scan(
 	options: ScanOptions & { fs: FsAdapter; cwd: string },
 ): Promise<MatcherContext> {
-	const { promise, resolve, reject } = Promise.withResolvers<MatcherContext>()
+	let resolve!: (ctx: MatcherContext) => void
+	let reject!: (err: Error) => void
+	const promise = new Promise<MatcherContext>((res, rej) => {
+		resolve = res
+		reject = rej
+	})
 	scanCb(options, (err, ctx) => {
 		if (err) {
 			reject(err)

--- a/src/browser_stream.ts
+++ b/src/browser_stream.ts
@@ -1,7 +1,7 @@
 import type { ScanOptions, FsAdapter } from "./types.js"
 
 import { MatcherStream } from "./patterns/matcherStream.js"
-export type * from "./types.js"
+export * from "./types.js"
 
 /**
  * Scan the directory for included files based on the provided targets.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export { scan } from "./scan.js"
 export { scanCb } from "./scanCb.js"
 export { scanStream } from "./stream.js"
-export type * from "./types.js"
+export * from "./types.js"

--- a/src/patterns/matcherStream.ts
+++ b/src/patterns/matcherStream.ts
@@ -1,83 +1,18 @@
-import type { Dirent } from "node:fs"
-
 import type { MatcherContext, Total } from "../patterns/matcherContext.js"
 import type { ScanOptions, FsAdapter } from "../types.js"
 import type { Resource } from "./resource.js"
 import type { RuleMatch } from "./rule.js"
+import type {
+	EventMap,
+	EventListener,
+	EventListenerObject,
+} from "./matcherStreamTypes.js"
 
 import { scanParallel } from "../scanParallel.js"
 import { unixify } from "../unixify.js"
 import { walkPatchResult, walkPatchTotal, propagateTotals, type WalkResult } from "../walk.js"
 
-/**
- * Post-scan entry information.
- *
- * @since 0.6.0
- */
-export type EntryInfo = {
-	/**
-	 * The relative path of the entry.
-	 *
-	 * @since 0.6.0
-	 */
-	path: string
-
-	/**
-	 * The directory entry.
-	 *
-	 * @since 0.6.0
-	 */
-	dirent: Dirent
-
-	/**
-	 * Whether the entry was ignored.
-	 *
-	 * @since 0.6.0
-	 */
-	match: RuleMatch
-}
-
-/**
- * @see {@link MatcherStream} uses it for the "dirent" event.
- *
- * @since 0.6.0
- */
-export type EntryListener = (info: EntryInfo) => void
-// export type SourceListener = (source: Source) => void
-/**
- * @see {@link MatcherStream} uses it for the "end" event.
- *
- * @since 0.6.0
- */
-export type EndListener = (ctx: MatcherContext) => void
-
-/**
- * @see {@link MatcherStream} uses it for its event map.
- *
- * @since 0.6.0
- */
-export type EventMap = {
-	dirent: CustomEvent<EntryInfo>
-	end: CustomEvent<MatcherContext>
-}
-
-/**
- * @see {@link MatcherStream} uses it for its event map.
- *
- * @since 0.11.0
- */
-interface EventListener<K extends keyof EventMap> {
-	(evt: EventMap[K]): void
-}
-
-/**
- * @see {@link MatcherStream} uses it for its event map.
- *
- * @since 0.11.0
- */
-interface EventListenerObject<K extends keyof EventMap> {
-	handleEvent(object: EventMap[K]): void
-}
+export type { EntryInfo, EntryListener, EndListener, EventMap } from "./matcherStreamTypes.js"
 
 /**
  * Event emitter.
@@ -106,7 +41,7 @@ export class MatcherStream extends EventTarget {
 
 	override addEventListener<K extends keyof EventMap>(
 		type: K,
-		callback: EventListenerObject<K> | EventListener<K>,
+		callback: EventListenerObject<K> | EventListener<K> | null,
 		options?: boolean | AddEventListenerOptions,
 	): void {
 		super.addEventListener(type as string, callback as any, options)
@@ -114,14 +49,14 @@ export class MatcherStream extends EventTarget {
 
 	override removeEventListener<K extends keyof EventMap>(
 		type: K,
-		callback: EventListenerObject<K> | EventListener<K>,
+		callback: EventListenerObject<K> | EventListener<K> | null,
 		options?: boolean | EventListenerOptions,
 	): void {
 		super.removeEventListener(type as string, callback as any, options)
 	}
 
 	override dispatchEvent(event: EventMap[keyof EventMap]): boolean {
-		return super.dispatchEvent(event)
+		return super.dispatchEvent(event as Event)
 	}
 
 	/**
@@ -130,7 +65,12 @@ export class MatcherStream extends EventTarget {
 	 * @since 0.8.0
 	 */
 	start(): Promise<void> {
-		const { promise, resolve, reject } = Promise.withResolvers<void>()
+		let resolve!: () => void
+		let reject!: (err: Error) => void
+		const promise = new Promise<void>((res, rej) => {
+			resolve = res
+			reject = rej
+		})
 		this.startCb((err) => {
 			if (err) {
 				reject(err)

--- a/src/patterns/matcherStreamTypes.ts
+++ b/src/patterns/matcherStreamTypes.ts
@@ -1,0 +1,73 @@
+import type { Dirent } from "node:fs"
+import type { MatcherContext } from "./matcherContext.js"
+import type { RuleMatch } from "./rule.js"
+
+/**
+ * Post-scan entry information.
+ *
+ * @since 0.6.0
+ */
+export type EntryInfo = {
+	/**
+	 * The relative path of the entry.
+	 *
+	 * @since 0.6.0
+	 */
+	path: string
+
+	/**
+	 * The directory entry.
+	 *
+	 * @since 0.6.0
+	 */
+	dirent: Dirent
+
+	/**
+	 * Whether the entry was ignored.
+	 *
+	 * @since 0.6.0
+	 */
+	match: RuleMatch
+}
+
+/**
+ * @see {@link MatcherStream} uses it for the "dirent" event.
+ *
+ * @since 0.6.0
+ */
+export type EntryListener = (info: EntryInfo) => void
+// export type SourceListener = (source: Source) => void
+/**
+ * @see {@link MatcherStream} uses it for the "end" event.
+ *
+ * @since 0.6.0
+ */
+export type EndListener = (ctx: MatcherContext) => void
+
+/**
+ * @see {@link MatcherStream} uses it for its event map.
+ *
+ * @since 0.6.0
+ */
+export type EventMap = {
+	dirent: CustomEvent<EntryInfo>
+	end: CustomEvent<MatcherContext>
+}
+
+/**
+ * @see {@link MatcherStream} uses it for its event map.
+ *
+ * @since 0.11.0
+ */
+export interface EventListener<K extends keyof EventMap> {
+	(evt: EventMap[K]): void
+}
+
+/**
+ * @see {@link MatcherStream} uses it for its event map.
+ *
+ * @since 0.11.0
+ */
+export interface EventListenerObject<K extends keyof EventMap> {
+	handleEvent(object: EventMap[K]): void
+}

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -6,7 +6,7 @@ import type { ScanOptions } from "./types.js"
 
 import { scan as browserScan } from "./browser_scan.js"
 import { scanCb as browserScanCb } from "./scanCb.js"
-export type * from "./types.js"
+export * from "./types.js"
 
 /**
  * Scan the directory for included files based on the provided targets.

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -5,7 +5,7 @@ import type { MatcherStream } from "./patterns/matcherStream.js"
 import type { ScanOptions } from "./types.js"
 
 import { scanStream as browserStream } from "./browser_stream.js"
-export type * from "./types.js"
+export * from "./types.js"
 
 /**
  * Scan the directory for included files based on the provided targets.

--- a/ts-compat/ts4.7/patterns/matcherStream.d.ts
+++ b/ts-compat/ts4.7/patterns/matcherStream.d.ts
@@ -1,0 +1,55 @@
+import type { MatcherContext } from "../../../out/patterns/matcherContext.js"
+import type { ScanOptions, FsAdapter } from "../../../out/types.js"
+import type {
+	EventMap,
+	EventListener,
+	EventListenerObject,
+} from "../../../out/patterns/matcherStreamTypes.js"
+
+export type {
+	EntryInfo,
+	EntryListener,
+	EndListener,
+	EventMap,
+} from "../../../out/patterns/matcherStreamTypes.js"
+
+/**
+ * Event emitter.
+ * @augments EventTarget
+ *
+ * @since 0.6.0
+ */
+export declare class MatcherStream extends EventTarget {
+	constructor(
+		options: ScanOptions & {
+			fs: FsAdapter
+			cwd: string
+			noTimeout?: boolean
+		} & {
+			captureRejections?: boolean
+		},
+	)
+	addEventListener<K extends keyof EventMap>(
+		type: K,
+		callback: EventListenerObject<K> | EventListener<K> | null,
+		options?: boolean | AddEventListenerOptions,
+	): void
+	removeEventListener<K extends keyof EventMap>(
+		type: K,
+		callback: EventListenerObject<K> | EventListener<K> | null,
+		options?: boolean | EventListenerOptions,
+	): void
+	dispatchEvent(event: EventMap[keyof EventMap]): boolean
+	/**
+	 * Resolves when everything is scanned.
+	 *
+	 * @since 0.8.0
+	 */
+	start(): Promise<void>
+	/**
+	 * Resolves when everything is scanned. (Callback version)
+	 *
+	 * @since 0.11.0
+	 */
+	startCb(cb: (err: Error | null, ctx: MatcherContext) => void): void
+}

--- a/ts-compat/ts6.0/patterns/matcherStream.d.ts
+++ b/ts-compat/ts6.0/patterns/matcherStream.d.ts
@@ -1,0 +1,55 @@
+import type { MatcherContext } from "../../../out/patterns/matcherContext.js"
+import type { ScanOptions, FsAdapter } from "../../../out/types.js"
+import type {
+	EventMap,
+	EventListener,
+	EventListenerObject,
+} from "../../../out/patterns/matcherStreamTypes.js"
+
+export type {
+	EntryInfo,
+	EntryListener,
+	EndListener,
+	EventMap,
+} from "../../../out/patterns/matcherStreamTypes.js"
+
+/**
+ * Event emitter.
+ * @augments EventTarget
+ *
+ * @since 0.6.0
+ */
+export declare class MatcherStream extends EventTarget {
+	constructor(
+		options: ScanOptions & {
+			fs: FsAdapter
+			cwd: string
+			noTimeout?: boolean
+		} & {
+			captureRejections?: boolean
+		},
+	)
+	addEventListener<K extends keyof EventMap>(
+		type: K,
+		callback: EventListenerObject<K> | EventListener<K> | null,
+		options?: boolean | AddEventListenerOptions,
+	): void
+	removeEventListener<K extends keyof EventMap>(
+		type: K,
+		callback: EventListenerObject<K> | EventListener<K> | null,
+		options?: boolean | EventListenerOptions,
+	): void
+	dispatchEvent(event: EventMap[keyof EventMap]): boolean
+	/**
+	 * Resolves when everything is scanned.
+	 *
+	 * @since 0.8.0
+	 */
+	start(): Promise<void>
+	/**
+	 * Resolves when everything is scanned. (Callback version)
+	 *
+	 * @since 0.11.0
+	 */
+	startCb(cb: (err: Error | null, ctx: MatcherContext) => void): void
+}


### PR DESCRIPTION
This PR addresses Issue #21 by fixing broken types across TypeScript versions (4.x to 7.x) and improving compatibility for `EventTarget` extensions.

Key highlights:
- Fixed `MatcherStream` inheritance issues by explicitly allowing `null` in `addEventListener` and `removeEventListener` signatures.
- Replaced the modern `Promise.withResolvers` (introduced in Node 22 / TS 5.4) with a compatible `new Promise` constructor.
- Established a `ts-compat/` directory with manual `.d.ts` patches for TS 4.7+ and TS 6.0+, integrated via `typesVersions` in `package.json`.
- Refactored shared types to prevent duplication between the main implementation and compatibility patches.
- Added a `ts-compat` verification script that runs aliased TypeScript 4 and 6 compilers against the project source.
- Updated the `prerelease` script to ensure cross-version compatibility is checked automatically.
- Replaced `export type *` syntax with `export *` to support TypeScript versions older than 5.0.

All unit tests and quality checks pass, and the compatibility is verified against TS 4.9.5 and TS 6.0.0-dev.

---
*PR created automatically by Jules for task [14508237840821315839](https://jules.google.com/task/14508237840821315839) started by @Mopsgamer*