### PR TITLE
Fix patchers stat corruption and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,14 @@ await matcherContextRemovePath(ctx, options, "src/file.ts")
 await matcherContextAddPath(ctx, options, "src/file.ts")
 ```
 
+#### Edge Cases and Limitations
+
+- **Idempotency**: Patcher functions for files are **not idempotent**. Calling `matcherContextAddPath` multiple times for the same path without removing it first will corrupt the `totalFiles` and `totalMatchedFiles` counts in `ctx.total`. Always call `matcherContextRemovePath` before `matcherContextAddPath` if the path might already exist in the context.
+- **Directories**: Directory paths **must end with a slash** (e.g., `src/`). If you omit the slash, it will be treated as a file, and its contents will not be tracked or updated correctly.
+- **Renames**: To handle a file or directory rename, first call `matcherContextRemovePath` on the old path, then `matcherContextAddPath` on the new path.
+- **Source Files**: If a file that acts as an ignore source (like `.gitignore` or `package.json`) is added or changed, the patcher will automatically rescan the directory containing that source file to update the matching rules and state for all affected files.
+- **Depth**: Patchers respect the `depth` option provided in the `ScanOptions`. If you add a path deeper than the specified depth, it might not be fully processed or added to `ctx.paths`.
+
 ## Targets
 
 The following built-in scanners are available:

--- a/README.md
+++ b/README.md
@@ -174,6 +174,32 @@ const customFs = { readFile, readdir }
 await vign.scan({ cwd, fs: customFs, target })
 ```
 
+### Watching for changes
+
+You can use patchers to update the `MatcherContext` without rescanning the entire tree.
+This is useful for implementing file watchers.
+
+> [!IMPORTANT]
+> Directory paths must have a trailing slash.
+
+```ts
+import {
+	matcherContextAddPath,
+	matcherContextRemovePath,
+} from "view-ignored/patterns"
+
+// Handle "created"
+await matcherContextAddPath(ctx, options, "src/new-file.ts")
+
+// Handle "removed"
+await matcherContextRemovePath(ctx, options, "src/old-file.ts")
+
+// Handle "changed"
+// Best approach: remove and re-add
+await matcherContextRemovePath(ctx, options, "src/file.ts")
+await matcherContextAddPath(ctx, options, "src/file.ts")
+```
+
 ## Targets
 
 The following built-in scanners are available:

--- a/src/patterns/matcherContextPatch.ts
+++ b/src/patterns/matcherContextPatch.ts
@@ -41,8 +41,8 @@ export async function matcherContextAddPath(
 
 	const isDir = entry.endsWith("/")
 	const direntPath = isDir ? entry.slice(0, -1) : entry
-	if (isDir && direntPath === ".") {
-		return true
+	if (isDir && (direntPath === "." || ctx.total.has(direntPath) || ctx.paths.has(entry))) {
+		return isDir && direntPath === "."
 	}
 	const parentPath = dirname(direntPath)
 
@@ -63,29 +63,24 @@ export async function matcherContextAddPath(
 				promiseCb(resolve, reject),
 			)
 		})
-		ctx.paths.set(
-			entry,
-			await new Promise<RuleMatch>((resolve, reject) => {
-				target.ignores(
-					{
-						cwd,
-						entry: direntPath,
-						fs,
-						parentPath,
-						resource,
-						signal,
-						target,
-					},
-					promiseCb(resolve, reject),
-				)
-			}),
-		)
-		const total = ctx.total.get(parentPath)
-		if (!total) {
-			ctx.total.set(parentPath, { totalDirs: 1, totalFiles: 0, totalMatchedFiles: 0 })
-		} else if (total.totalFiles >= 0) {
-			total.totalDirs++
+		const match = await new Promise<RuleMatch>((resolve, reject) => {
+			target.ignores(
+				{
+					cwd,
+					entry: direntPath,
+					fs,
+					parentPath,
+					resource,
+					signal,
+					target,
+				},
+				promiseCb(resolve, reject),
+			)
+		})
+		if (!match.ignored) {
+			ctx.paths.set(entry, match)
 		}
+		updateTotals(ctx, parentPath, 0, 0, 1)
 		if (parentPath !== ".") {
 			void (await matcherContextAddPath(ctx, options, parentPath + "/"))
 		}
@@ -152,19 +147,12 @@ export async function matcherContextAddPath(
 		)
 	})
 
+	updateTotals(ctx, parentPath, 1, match.ignored ? 0 : 1, 0)
+
 	if (match.ignored) {
-		// 2.1. remove
-		await matcherContextRemovePath(ctx, options, entry)
 		return false
 	}
-	// 2.2. add
-	const total = ctx.total.get(parentPath)
-	if (!total) {
-		ctx.total.set(parentPath, { totalDirs: 0, totalFiles: 1, totalMatchedFiles: 1 })
-	} else {
-		total.totalFiles++
-		total.totalMatchedFiles++
-	}
+
 	ctx.paths.set(entry, match)
 	return true
 }
@@ -195,24 +183,25 @@ export async function matcherContextRemovePath(
 	if (isDir) {
 		// remove directories
 		let deletedDirs = 0,
-			deletedFiles = 0
-		const total = ctx.total.get(direntPath)!
-		for (const [element] of ctx.paths) {
-			if (!element.startsWith(entry)) {
-				continue
-			}
-			if (total && total.totalFiles >= 0) {
-				const isDir = element.endsWith("/")
-				if (isDir) {
-					deletedDirs++
-				} else {
-					deletedFiles++
-				}
-			}
-			ctx.paths.delete(element)
+			deletedFiles = 0,
+			deletedMatchedFiles = 0
+		const total = ctx.total.get(direntPath)
+		if (total) {
+			deletedDirs = total.totalDirs + 1
+			deletedFiles = total.totalFiles
+			deletedMatchedFiles = total.totalMatchedFiles
+			ctx.total.delete(direntPath)
+		} else {
+			deletedDirs = 1
 		}
 
-		deleteTotals(ctx, entry, deletedDirs, deletedFiles)
+		updateTotals(ctx, parentPath, -deletedFiles, -deletedMatchedFiles, -deletedDirs)
+
+		for (const [element] of ctx.paths) {
+			if (element.startsWith(entry)) {
+				ctx.paths.delete(element)
+			}
+		}
 
 		for (const [element] of ctx.external) {
 			if (!element.startsWith(direntPath)) {
@@ -261,27 +250,34 @@ export async function matcherContextRemovePath(
 	}
 	// remove path
 	// 1. change stats
-	{
-		const total = ctx.total.get(parentPath)
-		if (!total) {
-			ctx.total.set(parentPath, { totalDirs: 0, totalFiles: 0, totalMatchedFiles: 0 })
-		} else if (total.totalFiles >= 0) {
-			total.totalFiles--
-			total.totalMatchedFiles--
-		}
-	}
+	updateTotals(ctx, parentPath, -1, ctx.paths.has(entry) ? -1 : 0, 0)
+
 	// 2. remove from paths
 	ctx.paths.delete(entry)
 	return true
 }
 
-function deleteTotals(ctx: MatcherContext, entry: string, deletedDirs = 0, deletedFiles = 0) {
-	if (entry.endsWith("/")) ctx.total.delete(entry)
-	for (let parent = dirname(entry); parent !== "./"; parent = dirname(parent) + "/") {
+function updateTotals(
+	ctx: MatcherContext,
+	path: string,
+	deltaFiles: number,
+	deltaMatchedFiles: number,
+	deltaDirs: number,
+) {
+	for (let parent = path; ; ) {
 		const total = ctx.total.get(parent)
-		if (!total) continue
-		total.totalDirs -= deletedDirs
-		total.totalFiles -= deletedFiles
-		total.totalMatchedFiles -= deletedFiles
+		if (total) {
+			total.totalDirs += deltaDirs
+			total.totalFiles += deltaFiles
+			total.totalMatchedFiles += deltaMatchedFiles
+		} else {
+			ctx.total.set(parent, {
+				totalDirs: deltaDirs,
+				totalFiles: deltaFiles,
+				totalMatchedFiles: deltaMatchedFiles,
+			})
+		}
+		if (parent === "." || parent === "/") break
+		parent = dirname(parent)
 	}
 }

--- a/src/patterns/matcherContextPatch.ts
+++ b/src/patterns/matcherContextPatch.ts
@@ -41,7 +41,7 @@ export async function matcherContextAddPath(
 
 	const isDir = entry.endsWith("/")
 	const direntPath = isDir ? entry.slice(0, -1) : entry
-	if (isDir && (direntPath === "." || ctx.total.has(direntPath) || ctx.paths.has(entry))) {
+	if (isDir && (direntPath === "." || ctx.paths.has(entry))) {
 		return isDir && direntPath === "."
 	}
 	const parentPath = dirname(direntPath)

--- a/src/patterns/testMatcherContextPatch.test.ts
+++ b/src/patterns/testMatcherContextPatch.test.ts
@@ -356,9 +356,13 @@ describe("matcherContextAddPath", () => {
 			const c = await scan(opt)
 			expect(await matcherContextAddPath(c, opt, "test/")).toBeTrue()
 		})
-		test("ignored file is not added", async () => {
+		test("ignored file is not added to paths, but added to totals", async () => {
 			const c = await scan(opt)
+			const initialTotal = { ...c.total.get(".")! }
 			expect(await matcherContextAddPath(c, opt, "test")).toBeFalse()
+			expect(c.paths.has("test")).toBeFalse()
+			expect(c.total.get(".")!.totalFiles).toBe(initialTotal.totalFiles + 1)
+			expect(c.total.get(".")!.totalMatchedFiles).toBe(initialTotal.totalMatchedFiles)
 		})
 		test("source file is changed", async () => {
 			const o = {
@@ -772,6 +776,38 @@ describe("matcherContextRemovePath", () => {
 			})
 		})
 	})
+	describe("stat consistency", () => {
+		test("adding then removing ignored file restores totals", async () => {
+			const c = await scan(opt)
+			const initialTotal = { ...c.total.get(".")! }
+			await matcherContextAddPath(c, opt, "ignored.js")
+			await matcherContextRemovePath(c, opt, "ignored.js")
+			expect(c.total.get(".")!).toEqual(initialTotal)
+		})
+
+		test("removing directory accounts for ignored files in totals", async () => {
+			const o = {
+				...opt,
+				fs: patchFS((json) => {
+					;(json.src as any)["ignored.js"] = "..."
+					return json
+				}),
+			}
+			const c = await scan(o)
+			const initialTotal = { ...c.total.get(".")! }
+			const srcTotal = { ...c.total.get("src")! }
+
+			await matcherContextRemovePath(c, o, "src/")
+
+			const finalTotal = c.total.get(".")!
+			expect(finalTotal.totalFiles).toBe(initialTotal.totalFiles - srcTotal.totalFiles)
+			expect(finalTotal.totalMatchedFiles).toBe(
+				initialTotal.totalMatchedFiles - srcTotal.totalMatchedFiles,
+			)
+			expect(finalTotal.totalDirs).toBe(initialTotal.totalDirs - srcTotal.totalDirs - 1)
+		})
+	})
+
 	describe("max depth 1", () => {
 		test("should change ctx.total", async () => {
 			const c = await scan(optDepth1)


### PR DESCRIPTION
Fixed stat corruption in `matcherContextAddPath` and `matcherContextRemovePath` by correctly accounting for ignored files in `totalFiles` vs `totalMatchedFiles`. Added documentation for file watching in `README.md`.

---
*PR created automatically by Jules for task [16058779980712723659](https://jules.google.com/task/16058779980712723659) started by @Mopsgamer*