### PR TITLE
Add coverage reporting and badge

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -33,3 +33,14 @@ jobs:
       - name: Run prerelease
         run: |
           bun run prerelease
+
+      - name: Generate coverage
+        run: |
+          bun run coverage -- --coverage-reporter=lcov
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/lcov.info
+          fail_ci_if_error: true

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 *.cpuprofile
 CPU.*.*
 HEAP.*.*
+coverage

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 [![npm-version](https://img.shields.io/npm/v/view-ignored.svg)](https://www.npmjs.com/package/view-ignored)
 [![npm-downloads](https://img.shields.io/npm/dm/view-ignored.svg)](https://www.npmjs.com/package/view-ignored)
+[![coverage](https://codecov.io/gh/Mopsgamer/view-ignored/graph/badge.svg?token=O5I06Y2A86)](https://codecov.io/gh/Mopsgamer/view-ignored)
 ![node-v20-or-later](https://img.shields.io/badge/node->=22-salad?repo=Mopsgamer/view-ignored.svg)
 ![ts-v5-or-later](https://img.shields.io/badge/ts->=5.7-salad?repo=Mopsgamer/view-ignored)
 [![speed-fast](https://img.shields.io/badge/speed-fast-salad?repo=Mopsgamer/view-ignored.svg)](https://github.com/Mopsgamer/view-ignored/tree/main/benchmarks)

--- a/src/patterns/jsrjson.ts
+++ b/src/patterns/jsrjson.ts
@@ -67,18 +67,17 @@ const extract: ExtractorFn = (source, content) => {
 	const target = dist.publish ?? dist
 
 	if (target.exclude && Array.isArray(target.exclude)) {
-		exclude.pattern.push(...target.exclude)
+		for (const pattern of target.exclude) {
+			resolveNegatable(pattern, false, include, exclude)
+		}
 	}
 
 	if (target.include && Array.isArray(target.include)) {
-		include.pattern.push(...target.include)
-	}
-
-	for (const si of [include, exclude]) {
-		for (const pattern of si.pattern) {
+		for (const pattern of target.include) {
 			resolveNegatable(pattern, true, include, exclude)
 		}
 	}
+
 	source.rules.push(include, exclude)
 	return
 }

--- a/src/patterns/testJsrJson.test.ts
+++ b/src/patterns/testJsrJson.test.ts
@@ -2,7 +2,7 @@ import type { Source } from "./source.js"
 
 import { describe, expect, test } from "bun:test"
 
-import { makeJsrJsonExtractor } from "./jsrjson.js"
+import { makeJsrJsonExtractor, makeJsrJsoncExtractor } from "./jsrjson.js"
 
 describe("jsr.json", () => {
 	const ext = makeJsrJsonExtractor("jsr.json")
@@ -29,5 +29,59 @@ describe("jsr.json", () => {
 			rules: [],
 		}
 		expect(ext.extract(source, Buffer.from("{}", "utf-8"))).not.toBeInstanceOf(Error)
+	})
+
+	test("parses include and exclude", () => {
+		const source: Source = {
+			inverted: false,
+			path: "jsr.json",
+			rules: [],
+		}
+		const content = JSON.stringify({
+			exclude: ["test"],
+			include: ["src"],
+		})
+		expect(ext.extract(source, Buffer.from(content, "utf-8"))).toBeUndefined()
+		expect(source.rules).toHaveLength(2)
+		expect(source.rules[0]!.pattern).toContain("src")
+		expect(source.rules[1]!.pattern).toContain("test")
+	})
+
+	test("parses publish override", () => {
+		const source: Source = {
+			inverted: false,
+			path: "jsr.json",
+			rules: [],
+		}
+		const content = JSON.stringify({
+			publish: {
+				exclude: ["dist/*.map"],
+				include: ["dist"],
+			},
+		})
+		expect(ext.extract(source, Buffer.from(content, "utf-8"))).toBeUndefined()
+		expect(source.rules).toHaveLength(2)
+		expect(source.rules[0]!.pattern).toContain("dist")
+		expect(source.rules[1]!.pattern).toContain("dist/*.map")
+	})
+})
+
+describe("jsr.jsonc", () => {
+	const ext = makeJsrJsoncExtractor("jsr.jsonc")
+	test("parses with comments", () => {
+		const source: Source = {
+			inverted: false,
+			path: "jsr.jsonc",
+			rules: [],
+		}
+		const content = `
+		{
+			// comment
+			"include": ["src"]
+		}
+		`
+		expect(ext.extract(source, Buffer.from(content, "utf-8"))).toBeUndefined()
+		expect(source.rules).toHaveLength(2)
+		expect(source.rules[0]!.pattern).toContain("src")
 	})
 })


### PR DESCRIPTION
This PR adds test coverage reporting using Codecov and includes a coverage badge in the README. 

Key changes:
- New `coverage` script: `bun test --coverage`.
- GitHub Actions update: `prerelease.yml` now generates an LCOV report and uploads it to Codecov.
- Bug fix: Resolved an infinite loop in `src/patterns/jsrjson.ts` where rule arrays were being mutated during iteration.
- Coverage boost: Added comprehensive tests for `jsr.json`, `jsr.jsonc`, and error paths in `jsrManifest.ts` and `npmManifest.ts`.
- Repository hygiene: Added `coverage/` to `.gitignore`.

---
*PR created automatically by Jules for task [6106972726514757448](https://jules.google.com/task/6106972726514757448) started by @Mopsgamer*